### PR TITLE
Implement exact percentile calculation using linear interpolation

### DIFF
--- a/jobeval/src/utils/blsComparison.ts
+++ b/jobeval/src/utils/blsComparison.ts
@@ -81,7 +81,13 @@ function calculateExactPercentile(
   }
   if (salary > points[points.length - 1].salary) {
     // Above 90th percentile - cap at reasonable maximum
-    return Math.max(90, 90 + Math.round(((salary - points[points.length - 1].salary) / points[points.length - 1].salary) * 10));
+    return Math.max(
+      90,
+      90 +
+        Math.round(
+          ((salary - points[points.length - 1].salary) / points[points.length - 1].salary) * 10
+        )
+    );
   }
 
   return 50; // Fallback (should rarely happen)


### PR DESCRIPTION
- Replace range-based percentile labels (e.g., "10th-25th percentile") with exact percentile values (e.g., "19th percentile")
- Add calculateExactPercentile function that uses linear interpolation between known percentile points (10th, 25th, 50th, 75th, 90th)
- Add getOrdinalSuffix helper to format percentiles with proper ordinal suffixes (st, nd, rd, th)
- Update checkAlignment messages to include exact percentile in comparison text
- Handles edge cases for salaries below 10th and above 90th percentiles

Example: $85,000 between $72,800 (10th) and $96,750 (25th) now shows as "18th percentile" instead of "10th-25th percentile"