### PR TITLE
refactor(store): add international types to company store

### DIFF
--- a/jobeval/src/features/company-setup/companyStore.ts
+++ b/jobeval/src/features/company-setup/companyStore.ts
@@ -1,6 +1,16 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- Used in commented placeholders for Prompt #7
+import type { CountryCode, CurrencyCode } from "@/types/i18n";
+import type {
+  InternationalCompanyProfile,
+  CompanyProfile as LegacyCompanyProfile,
+} from "@/types/company-international";
 
+/**
+ * Legacy company profile interface (for backwards compatibility)
+ * @deprecated Use InternationalCompanyProfile instead
+ */
 export interface CompanyProfile {
   name: string;
   industry: string;
@@ -11,10 +21,25 @@ export interface CompanyProfile {
   state: string;
 }
 
+// Re-export international types for convenience
+export type { InternationalCompanyProfile, LegacyCompanyProfile };
+
+// Export type aliases for future use (Prompt #7)
+export type FutureCountryCode = CountryCode;
+export type FutureCurrencyCode = CurrencyCode;
+
 interface CompanyState {
+  // Current profile storage (will transition to InternationalCompanyProfile)
   profile: CompanyProfile | null;
+
+  // Actions
   setProfile: (profile: CompanyProfile) => void;
   clearProfile: () => void;
+
+  // Future: Add these methods (will be implemented in Prompt #7)
+  // getCountry: () => CountryCode;
+  // getCurrency: () => CurrencyCode;
+  // setInternationalProfile: (profile: InternationalCompanyProfile) => void;
 }
 
 export const useCompanyStore = create<CompanyState>()(


### PR DESCRIPTION
- Import CountryCode, CurrencyCode from i18n.ts
- Import InternationalCompanyProfile from company-international.ts
- Mark existing CompanyProfile as @deprecated
- Re-export international types for convenience
- Export type aliases for future use (FutureCountryCode, FutureCurrencyCode)
- Add commented placeholders for future methods
- Zero runtime changes - type updates only
- Existing functionality unchanged

Preparation for international company profiles (Prompt #7). No breaking changes - backwards compatible.

Part of globalization initiative.