### PR TITLE
feat: add pre-commit hooks for persistence file quality checks

### DIFF
--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env sh
+if [ -z "$husky_skip_init" ]; then
+  debug () {
+    if [ "$HUSKY_DEBUG" = "1" ]; then
+      echo "husky (debug) - $1"
+    fi
+  }
+
+  readonly hook_name="$(basename -- "$0")"
+  debug "starting $hook_name..."
+
+  if [ "$HUSKY" = "0" ]; then
+    debug "HUSKY env variable is set to 0, skipping hook"
+    exit 0
+  fi
+
+  if [ -f ~/.huskyrc ]; then
+    debug "sourcing ~/.huskyrc"
+    . ~/.huskyrc
+  fi
+
+  readonly husky_skip_init=1
+  export husky_skip_init
+  sh -e "$0" "$@"
+  exitCode="$?"
+
+  if [ $exitCode != 0 ]; then
+    echo "husky - $hook_name hook exited with code $exitCode (error)"
+  fi
+
+  if [ $exitCode = 127 ]; then
+    echo "husky - command not found in PATH=$PATH"
+  fi
+
+  exit $exitCode
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,26 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+# Change to the jobeval directory
+cd jobeval
+
+# Run lint-staged
+npx lint-staged
+
+# Additional checks for persistence files
+if git diff --cached --name-only | grep -q "jobeval/src/lib/persistence/"; then
+  echo "📁 Persistence files changed, running additional checks..."
+
+  # Type check persistence files
+  npm run type-check
+
+  # Ensure no console.logs in persistence code
+  # Strip "jobeval/" prefix from paths since we're already in that directory
+  if git diff --cached --name-only | grep "jobeval/src/lib/persistence/" | sed 's|^jobeval/||' | xargs -r grep -n "console.log" 2>/dev/null; then
+    echo "❌ Error: console.log found in persistence files"
+    echo "   Remove console.log statements before committing"
+    exit 1
+  fi
+
+  echo "✅ Persistence checks passed"
+fi

--- a/jobeval/package.json
+++ b/jobeval/package.json
@@ -53,6 +53,14 @@
     "xlsx": "^0.18.5"
   },
   "lint-staged": {
+    "src/lib/persistence/**/*.{ts,tsx}": [
+      "prettier --write",
+      "eslint --fix"
+    ],
+    "src/features/data-management/**/*.{ts,tsx}": [
+      "prettier --write",
+      "eslint --fix"
+    ],
     "src/**/*.{ts,tsx,css,json}": [
       "prettier --write"
     ]


### PR DESCRIPTION
Configure Husky and lint-staged to enforce code quality on persistence and data-management files before commits.

Changes:
- Add .husky/pre-commit hook with persistence-specific checks
- Configure lint-staged in package.json for targeted file formatting
- Run prettier and eslint automatically on persistence files
- Block commits containing console.log in persistence code
- Run TypeScript type checking when persistence files are modified

Pre-commit hook ensures:
✓ Code formatting with prettier
✓ Linting with eslint --fix
✓ Type safety with tsc --noEmit
✓ No debug console.log statements in production code

The hooks run automatically on:
- src/lib/persistence/**/*.{ts,tsx}
- src/features/data-management/**/*.{ts,tsx}