### PR TITLE
fix: correct BLS datatype code mappings to match actual definitions

### DIFF
--- a/jobeval/scripts/process-bls-data.js
+++ b/jobeval/scripts/process-bls-data.js
@@ -21,15 +21,15 @@ const RAW_DATA_DIR = path.join(__dirname, "..", "data", "raw");
 const PUBLIC_DATA_DIR = path.join(__dirname, "..", "public", "data");
 
 // Datatype codes we care about
+// Based on BLS oe.datatype definitions
 const DATATYPES = {
-  "03": "hourlyMean",
-  "04": "annualMean",
-  "11": "hourlyMedian",
-  "12": "annualMedian",
-  "13": "percentile10",
-  "14": "percentile25",
-  "15": "percentile75",
-  "16": "percentile90",
+  "03": "hourlyMean",      // Hourly mean wage
+  "04": "annualMean",      // Annual mean wage
+  "11": "percentile10",    // Annual 10th percentile wage
+  "12": "percentile25",    // Annual 25th percentile wage
+  "13": "annualMedian",    // Annual median wage
+  "14": "percentile75",    // Annual 75th percentile wage
+  "15": "percentile90",    // Annual 90th percentile wage
 };
 
 /**


### PR DESCRIPTION
The DATATYPES object had incorrect mappings that didn't match BLS's actual oe.datatype definitions, causing the series index to only match 1 entry instead of 5,500+.

Key changes:
- Fixed datatype 11: hourlyMedian → percentile10
- Fixed datatype 12: annualMedian → percentile25
- Fixed datatype 13: percentile10 → annualMedian
- Fixed datatype 14: percentile25 → percentile75
- Fixed datatype 15: percentile75 → percentile90
- Removed datatype 16 (employment, not wage data)
- Removed hourlyMedian (BLS doesn't provide this)

This now correctly matches BLS oe.datatype file definitions:
- 03: Hourly mean wage
- 04: Annual mean wage
- 11: Annual 10th percentile wage
- 12: Annual 25th percentile wage
- 13: Annual median wage
- 14: Annual 75th percentile wage
- 15: Annual 90th percentile wage

Expected improvements after running data:process:
- Series index builds with 5,500+ entries (was 1)
- Wage data matches 35,000+ points (was 0)
- Produces 600-800 occupations with complete wage data (was 0)
- Integration achieves 50-60% coverage