### PR TITLE
Fix salary range visualization with percentile-based positioning

### DIFF
--- a/src/features/results/components/SalaryRangeBar.tsx
+++ b/src/features/results/components/SalaryRangeBar.tsx
@@ -23,11 +23,54 @@ export default function SalaryRangeBar({
 }: SalaryRangeBarProps) {
   const { p10, p25, p50, p75, p90 } = percentiles;
 
-  // Calculate position percentages for each marker
-  const range = p90 - p10;
-  const getPosition = (value: number) => ((value - p10) / range) * 100;
+  // Calculate percentile position for the user's budget
+  // We need to interpolate between known percentiles
+  const getUserPercentile = (budget: number): number => {
+    // Below P10
+    if (budget <= p10) return 10;
+    // Between P10 and P25
+    if (budget <= p25) {
+      const range = p25 - p10;
+      const position = budget - p10;
+      return 10 + (position / range) * 15; // Interpolate between 10 and 25
+    }
+    // Between P25 and P50
+    if (budget <= p50) {
+      const range = p50 - p25;
+      const position = budget - p25;
+      return 25 + (position / range) * 25; // Interpolate between 25 and 50
+    }
+    // Between P50 and P75
+    if (budget <= p75) {
+      const range = p75 - p50;
+      const position = budget - p50;
+      return 50 + (position / range) * 25; // Interpolate between 50 and 75
+    }
+    // Between P75 and P90
+    if (budget <= p90) {
+      const range = p90 - p75;
+      const position = budget - p75;
+      return 75 + (position / range) * 15; // Interpolate between 75 and 90
+    }
+    // Above P90
+    return 90;
+  };
 
-  const userBudgetPosition = getPosition(userBudget); // Keep for debugging
+  const userPercentile = getUserPercentile(userBudget);
+  const userBudgetPosition = userPercentile; // Position directly matches percentile
+
+  // Determine color and status based on position
+  const getMarkerColor = () => {
+    if (userBudget >= p50) return "#22c55e"; // Green - at or above median
+    if (userBudget >= p25) return "#3b82f6"; // Blue - competitive range
+    return "#f97316"; // Orange - below competitive
+  };
+
+  const getStatusText = () => {
+    if (userBudget >= p50) return "At or Above Median";
+    if (userBudget >= p25) return "Competitive Range";
+    return "Below Competitive";
+  };
 
   // DEBUG: Log all values
   console.log("🔍 SalaryRangeBar Debug:");
@@ -36,97 +79,166 @@ export default function SalaryRangeBar({
   console.log("  P50:", p50);
   console.log("  P75:", p75);
   console.log("  P90:", p90);
-  console.log("  User Budget:", userBudget, "→ Position:", userBudgetPosition.toFixed(2) + "%");
-  console.log("  Range (P90-P10):", range);
-  console.log("  NOTE: Budget marker currently disabled for rebuild");
+  console.log("  User Budget:", userBudget);
+  console.log("  Calculated Percentile:", userPercentile.toFixed(1) + "th");
+  console.log("  Position on bar:", userBudgetPosition.toFixed(1) + "%");
+
+  const markerColor = getMarkerColor();
+  const statusText = getStatusText();
 
   return (
     <div className="w-full" style={{ width: "100%", minWidth: "0", maxWidth: "100%" }}>
-      {/* Range bar */}
-      <div
-        className="relative h-4 bg-gradient-to-r from-blue-200 via-blue-300 to-blue-400 rounded-full mb-8"
-        style={{ width: "100%", minWidth: "0", maxWidth: "100%", display: "block" }}
-      >
-        {/* User budget marker - Dynamic positioning based on calculation */}
-        {userBudget >= p10 && userBudget <= p90 && (
-          <div
-            style={{
-              position: "absolute",
-              left: `calc(${userBudgetPosition}% - 12px)`, // Subtract half marker width to center
-              top: "0",
-              width: "24px",
-              height: "24px",
-              marginTop: "-4px", // Position slightly above bar
-              pointerEvents: "none",
-            }}
-          >
-            {/* Marker circle */}
+      {/* Horizontal Bar Chart */}
+      <div className="relative mb-20">
+        {/* Main gradient bar representing the full salary range */}
+        <div className="relative h-8 bg-gradient-to-r from-orange-200 via-blue-200 to-green-200 rounded-lg overflow-visible">
+          {/* Percentile markers */}
+          <div className="absolute inset-0">
+            {/* 10th percentile line */}
             <div
-              style={{
-                width: "24px",
-                height: "24px",
-                borderRadius: "50%",
-                backgroundColor:
-                  userBudget >= p50 ? "#22c55e" : userBudget >= p25 ? "#eab308" : "#f97316",
-                border: "4px solid white",
-                boxShadow: "0 4px 6px rgba(0, 0, 0, 0.1)",
-              }}
+              className="absolute top-0 bottom-0 w-0.5 bg-gray-600 opacity-70"
+              style={{ left: "10%" }}
             />
-            {/* Label */}
+            {/* 25th percentile line */}
             <div
+              className="absolute top-0 bottom-0 w-0.5 bg-gray-700 opacity-80"
+              style={{ left: "25%" }}
+            />
+            {/* 50th percentile (median) line - more prominent */}
+            <div
+              className="absolute top-0 bottom-0 w-1.5 bg-green-700 opacity-90"
+              style={{ left: "50%" }}
+            />
+            {/* 75th percentile line */}
+            <div
+              className="absolute top-0 bottom-0 w-0.5 bg-gray-700 opacity-80"
+              style={{ left: "75%" }}
+            />
+            {/* 90th percentile line */}
+            <div
+              className="absolute top-0 bottom-0 w-0.5 bg-gray-600 opacity-70"
+              style={{ left: "90%" }}
+            />
+          </div>
+
+          {/* User budget marker - Diamond shape */}
+          <div
+            className="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 z-10"
+            style={{ left: `${userBudgetPosition}%` }}
+          >
+            {/* Diamond/marker */}
+            <div
+              className="relative flex items-center justify-center"
               style={{
-                position: "absolute",
-                top: "30px",
-                left: "50%",
-                transform: "translateX(-50%)",
-                whiteSpace: "nowrap",
-                backgroundColor: "#1f2937",
-                color: "white",
-                fontSize: "12px",
-                fontWeight: "500",
-                padding: "4px 8px",
-                borderRadius: "4px",
+                width: "32px",
+                height: "32px",
               }}
             >
-              Your Budget
+              {/* Diamond background */}
+              <div
+                className="absolute"
+                style={{
+                  width: "24px",
+                  height: "24px",
+                  backgroundColor: markerColor,
+                  transform: "rotate(45deg)",
+                  border: "3px solid white",
+                  boxShadow: "0 2px 8px rgba(0, 0, 0, 0.2)",
+                }}
+              />
+              {/* Pulse animation */}
+              <div
+                className="absolute animate-ping"
+                style={{
+                  width: "24px",
+                  height: "24px",
+                  backgroundColor: markerColor,
+                  opacity: 0.3,
+                  transform: "rotate(45deg)",
+                }}
+              />
             </div>
           </div>
-        )}
+        </div>
+
+        {/* Status label below marker */}
+        <div
+          className="absolute top-10 -translate-x-1/2 z-10"
+          style={{ left: `${userBudgetPosition}%` }}
+        >
+          <div
+            className="px-3 py-1 rounded-full text-xs font-semibold whitespace-nowrap shadow-sm"
+            style={{
+              backgroundColor: markerColor,
+              color: "white",
+            }}
+          >
+            Your Budget
+          </div>
+          <div className="text-center mt-1">
+            <div className="text-xs text-gray-600 font-medium">
+              <CurrencyDisplay value={userBudget} abbreviate />
+            </div>
+            <div className="text-xs text-gray-500">{statusText}</div>
+          </div>
+        </div>
       </div>
 
       {/* Labels */}
       {showLabels && (
-        <div className="relative w-full">
-          <div className="flex justify-between items-start text-xs text-gray-600">
-            <div className="text-center" style={{ width: "20%" }}>
-              <div className="font-medium">10th</div>
-              <div className="text-gray-900 font-semibold mt-1">
-                <CurrencyDisplay value={p10} abbreviate />
-              </div>
+        <div className="relative w-full mt-8" style={{ minHeight: "45px" }}>
+          {/* 10th Percentile */}
+          <div
+            className="absolute"
+            style={{ left: "10%", transform: "translateX(-50%)", width: "70px" }}
+          >
+            <div className="text-sm font-semibold text-gray-700 text-center">10th</div>
+            <div className="text-gray-900 font-bold mt-1 text-center text-sm">
+              <CurrencyDisplay value={p10} abbreviate />
             </div>
-            <div className="text-center" style={{ width: "20%" }}>
-              <div className="font-medium">25th</div>
-              <div className="text-gray-900 font-semibold mt-1">
-                <CurrencyDisplay value={p25} abbreviate />
-              </div>
+          </div>
+
+          {/* 25th Percentile */}
+          <div
+            className="absolute"
+            style={{ left: "25%", transform: "translateX(-50%)", width: "70px" }}
+          >
+            <div className="text-sm font-semibold text-gray-700 text-center">25th</div>
+            <div className="text-gray-900 font-bold mt-1 text-center text-sm">
+              <CurrencyDisplay value={p25} abbreviate />
             </div>
-            <div className="text-center" style={{ width: "20%" }}>
-              <div className="font-medium text-green-700">Median</div>
-              <div className="text-gray-900 font-bold mt-1">
-                <CurrencyDisplay value={p50} abbreviate />
-              </div>
+          </div>
+
+          {/* 50th Percentile (Median) */}
+          <div
+            className="absolute"
+            style={{ left: "50%", transform: "translateX(-50%)", width: "70px" }}
+          >
+            <div className="text-sm font-bold text-green-700 text-center">Median</div>
+            <div className="text-gray-900 font-extrabold mt-1 text-center text-sm">
+              <CurrencyDisplay value={p50} abbreviate />
             </div>
-            <div className="text-center" style={{ width: "20%" }}>
-              <div className="font-medium">75th</div>
-              <div className="text-gray-900 font-semibold mt-1">
-                <CurrencyDisplay value={p75} abbreviate />
-              </div>
+          </div>
+
+          {/* 75th Percentile */}
+          <div
+            className="absolute"
+            style={{ left: "75%", transform: "translateX(-50%)", width: "70px" }}
+          >
+            <div className="text-sm font-semibold text-gray-700 text-center">75th</div>
+            <div className="text-gray-900 font-bold mt-1 text-center text-sm">
+              <CurrencyDisplay value={p75} abbreviate />
             </div>
-            <div className="text-center" style={{ width: "20%" }}>
-              <div className="font-medium">90th</div>
-              <div className="text-gray-900 font-semibold mt-1">
-                <CurrencyDisplay value={p90} abbreviate />
-              </div>
+          </div>
+
+          {/* 90th Percentile */}
+          <div
+            className="absolute"
+            style={{ left: "90%", transform: "translateX(-50%)", width: "70px" }}
+          >
+            <div className="text-sm font-semibold text-gray-700 text-center">90th</div>
+            <div className="text-gray-900 font-bold mt-1 text-center text-sm">
+              <CurrencyDisplay value={p90} abbreviate />
             </div>
           </div>
         </div>


### PR DESCRIPTION
- Replace DevExtreme Bullet chart with custom percentile visualization
- Implement accurate percentile interpolation for budget marker positioning
- Position is now based on percentile rank, not absolute dollar values
- Add gradient bar (orange → blue → green) representing competitiveness zones
- Add prominent percentile marker lines at 10%, 25%, 50%, 75%, 90%
- Median line (50th percentile) is most prominent with green color
- Diamond marker shows exact budget position with color coding:
  * Green: At or above median
  * Blue: Competitive range (25th-50th percentile)
  * Orange: Below competitive (<25th percentile)
- Add pulsing animation to budget marker for visual emphasis
- Position percentile labels to align with their corresponding marker lines
- Increase label size and prominence for better readability
- Add interpolation logic to calculate percentile between known points

Fixes: Incorrect positioning where budget marker appeared at ~15-20% when it should have been at ~27% for a $75K budget between P25 ($72K) and P50 ($106K).

Technical details:
- getUserPercentile() interpolates budget position between percentile ranges
- Direct mapping: percentile value = position on bar (27th percentile = 27%)
- Fixed percentile lines positioned at exact percentile values
- Removed dependency on DevExtreme components for this visualization