### PR TITLE
Unify salary visualizations with percentile-based positioning

### DIFF
--- a/src/features/results/components/SalaryRangeBar.tsx
+++ b/src/features/results/components/SalaryRangeBar.tsx
@@ -88,6 +88,66 @@ export default function SalaryRangeBar({
 
   return (
     <div className="w-full" style={{ width: "100%", minWidth: "0", maxWidth: "100%" }}>
+      {/* Percentile labels above the bar */}
+      {showLabels && (
+        <div className="relative w-full mb-3" style={{ minHeight: "45px" }}>
+          {/* 10th Percentile */}
+          <div
+            className="absolute"
+            style={{ left: "10%", transform: "translateX(-50%)", width: "70px" }}
+          >
+            <div className="text-sm font-semibold text-gray-700 text-center">10th</div>
+            <div className="text-gray-900 font-bold mt-1 text-center text-sm">
+              <CurrencyDisplay value={p10} abbreviate />
+            </div>
+          </div>
+
+          {/* 25th Percentile */}
+          <div
+            className="absolute"
+            style={{ left: "25%", transform: "translateX(-50%)", width: "70px" }}
+          >
+            <div className="text-sm font-semibold text-gray-700 text-center">25th</div>
+            <div className="text-gray-900 font-bold mt-1 text-center text-sm">
+              <CurrencyDisplay value={p25} abbreviate />
+            </div>
+          </div>
+
+          {/* 50th Percentile (Median) */}
+          <div
+            className="absolute"
+            style={{ left: "50%", transform: "translateX(-50%)", width: "70px" }}
+          >
+            <div className="text-sm font-bold text-green-700 text-center">Median</div>
+            <div className="text-gray-900 font-extrabold mt-1 text-center text-sm">
+              <CurrencyDisplay value={p50} abbreviate />
+            </div>
+          </div>
+
+          {/* 75th Percentile */}
+          <div
+            className="absolute"
+            style={{ left: "75%", transform: "translateX(-50%)", width: "70px" }}
+          >
+            <div className="text-sm font-semibold text-gray-700 text-center">75th</div>
+            <div className="text-gray-900 font-bold mt-1 text-center text-sm">
+              <CurrencyDisplay value={p75} abbreviate />
+            </div>
+          </div>
+
+          {/* 90th Percentile */}
+          <div
+            className="absolute"
+            style={{ left: "90%", transform: "translateX(-50%)", width: "70px" }}
+          >
+            <div className="text-sm font-semibold text-gray-700 text-center">90th</div>
+            <div className="text-gray-900 font-bold mt-1 text-center text-sm">
+              <CurrencyDisplay value={p90} abbreviate />
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Horizontal Bar Chart */}
       <div className="relative mb-20">
         {/* Main gradient bar representing the full salary range */}
@@ -183,66 +243,6 @@ export default function SalaryRangeBar({
           </div>
         </div>
       </div>
-
-      {/* Labels */}
-      {showLabels && (
-        <div className="relative w-full mt-8" style={{ minHeight: "45px" }}>
-          {/* 10th Percentile */}
-          <div
-            className="absolute"
-            style={{ left: "10%", transform: "translateX(-50%)", width: "70px" }}
-          >
-            <div className="text-sm font-semibold text-gray-700 text-center">10th</div>
-            <div className="text-gray-900 font-bold mt-1 text-center text-sm">
-              <CurrencyDisplay value={p10} abbreviate />
-            </div>
-          </div>
-
-          {/* 25th Percentile */}
-          <div
-            className="absolute"
-            style={{ left: "25%", transform: "translateX(-50%)", width: "70px" }}
-          >
-            <div className="text-sm font-semibold text-gray-700 text-center">25th</div>
-            <div className="text-gray-900 font-bold mt-1 text-center text-sm">
-              <CurrencyDisplay value={p25} abbreviate />
-            </div>
-          </div>
-
-          {/* 50th Percentile (Median) */}
-          <div
-            className="absolute"
-            style={{ left: "50%", transform: "translateX(-50%)", width: "70px" }}
-          >
-            <div className="text-sm font-bold text-green-700 text-center">Median</div>
-            <div className="text-gray-900 font-extrabold mt-1 text-center text-sm">
-              <CurrencyDisplay value={p50} abbreviate />
-            </div>
-          </div>
-
-          {/* 75th Percentile */}
-          <div
-            className="absolute"
-            style={{ left: "75%", transform: "translateX(-50%)", width: "70px" }}
-          >
-            <div className="text-sm font-semibold text-gray-700 text-center">75th</div>
-            <div className="text-gray-900 font-bold mt-1 text-center text-sm">
-              <CurrencyDisplay value={p75} abbreviate />
-            </div>
-          </div>
-
-          {/* 90th Percentile */}
-          <div
-            className="absolute"
-            style={{ left: "90%", transform: "translateX(-50%)", width: "70px" }}
-          >
-            <div className="text-sm font-semibold text-gray-700 text-center">90th</div>
-            <div className="text-gray-900 font-bold mt-1 text-center text-sm">
-              <CurrencyDisplay value={p90} abbreviate />
-            </div>
-          </div>
-        </div>
-      )}
 
       {/* Screen reader text */}
       <div className="sr-only">


### PR DESCRIPTION
Replace dollar-based positioning with percentile interpolation and create unified, compact design across In-Depth Analysis and Quick Advisory features.

PROBLEM:
Both visualizations positioned markers based on (value - P10) / (P90 - P10), treating the scale as a dollar range rather than percentile distribution.

Example bug:
- $75K in $51K-$208K range = 15.3% position ❌
- Should be: $75K between P25 ($72K) and P50 ($106K) = ~27th percentile ✓

SOLUTION:
- Implemented getUserPercentile() with linear interpolation
- Position now matches actual percentile (27th percentile = 27% on bar)
- Applied to both SalaryRangeBar and MarketPositionChart

DESIGN UNIFICATION & COMPACTNESS:
Standardized visual design across both features with compact layout: ✅ Same gradient bar (orange → blue → green)
✅ Same diamond marker with pulse animation
✅ Same percentile lines (positions, colors, widths) ✅ Same label positioning and typography
✅ Labels positioned ABOVE bar for ~50px space savings ✅ Consistent spacing and layout structure

TECHNICAL CHANGES:

SalaryRangeBar.tsx (In-Depth Analysis - Results page):
- Added percentile interpolation between known points
- Replaced DevExtreme with custom gradient visualization
- Fixed percentile lines at 10%, 25%, 50%, 75%, 90%
- Color-coded diamond marker (green/blue/orange) based on competitiveness
- Enhanced visual hierarchy: larger text, bolder weights, darker lines
- Median line most prominent (green-700, 1.5x width, 90% opacity)
- Moved percentile labels above bar for compact layout

MarketPositionChart.tsx (Quick Advisory):
- Applied same percentile interpolation logic
- Updated to match unified design system
- Blue diamond marker (consistent, simpler for quick analysis)
- Same gradient bar, percentile lines, and label layout
- Moved percentile labels above bar for compact layout

VISUAL HIERARCHY:
- Median (50th): Bold green, thick line, extrabold value
- 25th/75th: Gray-700 lines, semibold labels, bold values
- 10th/90th: Gray-600 lines, semibold labels, bold values

LAYOUT IMPROVEMENTS:
- Labels positioned above bar with 3px margin
- Saves ~50px vertical space per visualization
- Clearer visual flow: labels → percentile bar → marker
- More compact, professional appearance

Both components now provide consistent, accurate, compact market positioning.